### PR TITLE
♻️ Check DEFINED variable instead of values

### DIFF
--- a/cmake/modules/FindArnold.cmake
+++ b/cmake/modules/FindArnold.cmake
@@ -99,7 +99,7 @@ if (Arnold_INCLUDE_DIR AND EXISTS "${Arnold_INCLUDE_DIR}/ai_version.h")
   endforeach()
 
   # Concatenate the version components
-  if(Arnold_VERSION_ARCH AND Arnold_VERSION_MAJOR AND Arnold_VERSION_MINOR AND Arnold_VERSION_PATCH)
+  if(DEFINED Arnold_VERSION_ARCH AND DEFINED Arnold_VERSION_MAJOR AND DEFINED Arnold_VERSION_MINOR AND DEFINED Arnold_VERSION_PATCH)
     set(Arnold_VERSION "${Arnold_VERSION_ARCH}.${Arnold_VERSION_MAJOR}.${Arnold_VERSION_MINOR}.${Arnold_VERSION_PATCH}")
     message(STATUS "Found Arnold SDK version: ${Arnold_VERSION}")
   else()


### PR DESCRIPTION
# Check DEFINED variable instead of values

Because if the patch version is '0', as in Arnold 7.4.1.0, we get the message Could not determine all Arnold SDK version components from ai_version.h, since the condition checks the values instead of whether the variables are defined.

Before:
```
-- Selecting Windows SDK version 10.0.26100.0 to target Windows 10.0.22631.
-- OpenCV ARCH: x64
-- OpenCV RUNTIME: vc17
-- OpenCV STATIC: OFF
-- Found OpenCV 4.11.0 in D:/temp/compile/opencv-opencv-1d3b34d/install/x64/vc17/lib
-- You might need to add D:\temp\compile\opencv-opencv-1d3b34d\install\x64\vc17\bin to your PATH to be able to run your applications.
CMake Warning at vfx-cmake-modules/cmake/modules/FindArnold.cmake:106 (message):
  Could not determine all Arnold SDK version components from ai_version.h
Call Stack (most recent call first):
  CMakeLists.txt:43 (find_package)

-- Found Arnold: D:/temp/compile/Arnold/7.4.1.0/lib/ai.lib (found version "")
```

After:
```
-- Selecting Windows SDK version 10.0.26100.0 to target Windows 10.0.22631.
-- OpenCV ARCH: x64
-- OpenCV RUNTIME: vc17
-- OpenCV STATIC: OFF
-- Found OpenCV 4.11.0 in D:/temp/compile/opencv-opencv-1d3b34d/install/x64/vc17/lib
-- You might need to add D:\temp\compile\opencv-opencv-1d3b34d\install\x64\vc17\bin to your PATH to be able to run your applications.
-- Found Arnold SDK version: 7.4.1.0
Creating module description file for bin in
Creating module description file for ooKuwaharaArnoldImager in bin
-- Configuring done (1.1s)
-- Generating done (0.1s)
-- Build files have been written to: D:/temp/compile/kuwahara-arnold-imager/build
```